### PR TITLE
fix: 'use JuMP' missing from louvain.jl

### DIFF
--- a/louvain.jl
+++ b/louvain.jl
@@ -1,4 +1,5 @@
 # Inspired from `MiniZinc.jl/test/examples/louvain.jl`
+using JuMP
 
 w = Int[]
 


### PR DESCRIPTION
Otherwise, louvain.jl does not run on its own.